### PR TITLE
arc: tls macros for HS5x`

### DIFF
--- a/test/tls/tls-macros.h
+++ b/test/tls/tls-macros.h
@@ -24,7 +24,7 @@
 #include <tls-macros-alpha.h>
 #endif
 
-#ifdef __arc__
+#if defined(__arc__) || defined(__ARC64_ARCH32__)
 #include <tls-macros-arc.h>
 #endif
 


### PR DESCRIPTION
Use existing ARCompact/ARCv2 TLS macros for ARCv3 HS5x CPU famlily.